### PR TITLE
Put enrichment entries in Ant's table component

### DIFF
--- a/src/app/enrichment-entries/actions/index.ts
+++ b/src/app/enrichment-entries/actions/index.ts
@@ -7,6 +7,7 @@ export const LOAD_ENRICHMENT_ENTRIES_FAIL = '[Enrichment entries] load all fail'
 
 export class LoadEnrichmentEntriesAction implements Action {
   readonly type = LOAD_ENRICHMENT_ENTRIES;
+  constructor(public payload: string) {}
 }
 
 export class LoadEnrichmentEntriesSuccessAction implements Action {

--- a/src/app/enrichment-entries/effects/index.ts
+++ b/src/app/enrichment-entries/effects/index.ts
@@ -3,23 +3,33 @@ import { Effect, Actions, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Action } from '@ngrx/store';
-import { LOAD_ENRICHMENT_ENTRIES, LoadEnrichmentEntriesSuccessAction } from '../actions';
+import * as fromActions from '../actions';
 
 @Injectable()
 export class EnrichmentEntriesEffects {
 
   @Effect()
   loadAll$: Observable<Action> = this.actions$.pipe(
-    ofType(LOAD_ENRICHMENT_ENTRIES),
-    map(() => {
+    ofType(fromActions.LOAD_ENRICHMENT_ENTRIES),
+    map((/*action: fromActions.EnrichmentEntriesAction*/) => {
       /**
        * @TODO it's just temporarily hard coded until we have
        * a real data source up and running.
        */
-      return new LoadEnrichmentEntriesSuccessAction([{
-        key: '123',
+      return new fromActions.LoadEnrichmentEntriesSuccessAction([{
+        uuid: '123',
         timestamp: 123,
         user: 'bob',
+        value: 'lorem'
+      }, {
+        uuid: '456',
+        timestamp: 456,
+        user: 'simon',
+        value: 'ipsum'
+      }, {
+        uuid: '678',
+        timestamp: 678,
+        user: 'john',
         value: 'lorem'
       }]);
     })

--- a/src/app/enrichment-entries/enrichment-entries.component.html
+++ b/src/app/enrichment-entries/enrichment-entries.component.html
@@ -1,7 +1,13 @@
-<table>
+<nz-page-header nzTitle="Enrichment: {{ selectedType }}"></nz-page-header>
+<nz-table [nzLoading]="loading$ | async">
   <thead>
     <tr>
-      <th>key</th>
+      <th
+        [nzShowCheckbox]="true"
+        [nzChecked]="allChecked"
+        (nzCheckedChange)="onCheckAllChange($event)"
+      ></th>
+      <th>uuid</th>
       <th>timestamp</th>
       <th>user</th>
       <th>value</th>
@@ -9,10 +15,15 @@
   </thead>
   <tbody>
     <tr *ngFor="let entry of entries$ | async">
-      <td>{{ entry.key }}</td>
+      <td
+        [nzShowCheckbox]="true"
+        [nzChecked]="!!checkedMap[entry.uuid]"
+        (nzCheckedChange)="onCheckChange($event, entry)"
+      ></td>
+      <td>{{ entry.uuid }}</td>
       <td>{{ entry.timestamp }}</td>
       <td>{{ entry.user }}</td>
       <td>{{ entry.value }}</td>
     </tr>
   </tbody>
-</table>
+</nz-table>

--- a/src/app/enrichment-entries/enrichment-entries.component.ts
+++ b/src/app/enrichment-entries/enrichment-entries.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { LoadEnrichmentEntriesAction } from './actions';
 import { Store, select } from '@ngrx/store';
-import { State, getEntryItems } from './reducers';
+import { State, getEntryItems, isLoading } from './reducers';
 import { EnrichmentEntry } from './models';
 import { Observable } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-enrichment-entries',
@@ -13,13 +14,47 @@ import { Observable } from 'rxjs';
 export class EnrichmentEntriesComponent implements OnInit {
 
   entries$: Observable<EnrichmentEntry[]>;
+  entries: EnrichmentEntry[];
+  loading$: Observable<boolean>;
+  checkedMap: { [key: string]: boolean } = {};
+  allChecked = false;
+  selectedType = '';
 
-  constructor(private store: Store<State>) {
+  constructor(
+    private store: Store<State>,
+    private activatedRoute: ActivatedRoute
+  ) {
     this.entries$ = store.pipe(select(getEntryItems));
+    this.entries$.subscribe((entries: EnrichmentEntry[]) => {
+      this.entries = entries;
+    });
+
+    this.loading$ = store.pipe(select(isLoading));
+
+    this.activatedRoute.params.subscribe((params) => {
+      this.selectedType = params.type;
+    });
   }
 
   ngOnInit() {
-    this.store.dispatch(new LoadEnrichmentEntriesAction());
+    this.store.dispatch(new LoadEnrichmentEntriesAction(this.selectedType));
   }
 
+  onCheckAllChange(checked: boolean) {
+    this.entries.forEach((entry: EnrichmentEntry) => {
+      this.checkedMap[entry.uuid] = checked;
+    });
+    this.updateCheckStatus();
+  }
+
+  onCheckChange(checked: boolean, entry: EnrichmentEntry) {
+    this.checkedMap[entry.uuid] = checked;
+    this.updateCheckStatus();
+  }
+
+  updateCheckStatus() {
+    this.allChecked = this.entries.every((entry: EnrichmentEntry) => {
+      return !!this.checkedMap[entry.uuid];
+    });
+  }
 }

--- a/src/app/enrichment-entries/enrichment-entries.module.ts
+++ b/src/app/enrichment-entries/enrichment-entries.module.ts
@@ -6,6 +6,7 @@ import { reducer } from './reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { EnrichmentEntriesEffects } from './effects';
 import { EnrichmentEntriesRoutingModule } from './enrichment-entries-routing.module';
+import { NzTableModule, NzPageHeaderModule, NzIconModule } from 'ng-zorro-antd';
 
 
 @NgModule({
@@ -14,7 +15,10 @@ import { EnrichmentEntriesRoutingModule } from './enrichment-entries-routing.mod
     CommonModule,
     EnrichmentEntriesRoutingModule,
     StoreModule.forFeature('enrichment-entries', reducer),
-    EffectsModule.forFeature([ EnrichmentEntriesEffects ])
+    EffectsModule.forFeature([ EnrichmentEntriesEffects ]),
+    NzTableModule,
+    NzPageHeaderModule,
+    NzIconModule
   ]
 })
 export class EnrichmentEntriesModule { }

--- a/src/app/enrichment-entries/models/index.ts
+++ b/src/app/enrichment-entries/models/index.ts
@@ -1,5 +1,5 @@
 export interface EnrichmentEntry {
-  key: string;
+  uuid: string;
   timestamp: number;
   user: string;
   value: string;

--- a/src/app/enrichment-entries/reducers/index.ts
+++ b/src/app/enrichment-entries/reducers/index.ts
@@ -45,3 +45,8 @@ export const getEntryItems = createSelector(
   getEnrichmentEntriesState,
   (state: State) => state.items
 );
+
+export const isLoading = createSelector(
+  getEnrichmentEntriesState,
+  (state: State) => state.loading
+);


### PR DESCRIPTION
In this PR, I put the enrichment entries in the basic table component from Ant Design. 

I also added checkboxes for each row and added a "select all" checkbox.

Also changed the EnrichmentEntry model's property from key to uuid.

From now on, the component is receiving the type property from the query string to be able to get the entries from the server by type.

The table is already prepared for the case when the app is loading from the entries from the server and it's in pending state. It means that a spinner appears when the table is in pending state.