### PR TITLE
Add service to get enrichment entries from server

### DIFF
--- a/src/app/enrichment-entries/enrichment-entries.component.html
+++ b/src/app/enrichment-entries/enrichment-entries.component.html
@@ -1,5 +1,8 @@
 <nz-page-header nzTitle="Enrichment: {{ selectedType }}"></nz-page-header>
-<nz-table [nzLoading]="loading$ | async">
+<nz-table
+  [nzLoading]="loading$ | async"
+  [nzData]="entries$ | async"
+>
   <thead>
     <tr>
       <th

--- a/src/app/enrichment-entries/enrichment-entries.module.ts
+++ b/src/app/enrichment-entries/enrichment-entries.module.ts
@@ -6,11 +6,16 @@ import { reducer } from './reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { EnrichmentEntriesEffects } from './effects';
 import { EnrichmentEntriesRoutingModule } from './enrichment-entries-routing.module';
-import { NzTableModule, NzPageHeaderModule, NzIconModule } from 'ng-zorro-antd';
+import { NzTableModule, NzPageHeaderModule, NzIconModule, NzMessageService } from 'ng-zorro-antd';
+import { EnrichmentEntriesService } from './services/enrichment-entries.service';
 
 
 @NgModule({
   declarations: [EnrichmentEntriesComponent],
+  providers: [
+    EnrichmentEntriesService,
+    NzMessageService
+  ],
   imports: [
     CommonModule,
     EnrichmentEntriesRoutingModule,

--- a/src/app/enrichment-entries/reducers/index.ts
+++ b/src/app/enrichment-entries/reducers/index.ts
@@ -5,11 +5,13 @@ import * as fromActions from '../actions';
 export interface State {
   loading: boolean;
   items: EnrichmentEntry[];
+  error: string;
 }
 
 const initialState: State = {
   loading: false,
-  items: []
+  items: [],
+  error: ''
 };
 
 export function reducer(state: State = initialState, action: fromActions.EnrichmentEntriesAction): State {
@@ -30,6 +32,7 @@ export function reducer(state: State = initialState, action: fromActions.Enrichm
     case fromActions.LOAD_ENRICHMENT_ENTRIES_FAIL: {
       return {
         ...state,
+        error: action.payload.message,
         loading: false,
       };
     }

--- a/src/app/enrichment-entries/services/enrichment-entries.service.ts
+++ b/src/app/enrichment-entries/services/enrichment-entries.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { EnrichmentEntry } from '../models';
+import { catchError, map } from 'rxjs/operators';
+
+@Injectable()
+export class EnrichmentEntriesService {
+
+  constructor(private http: HttpClient) {}
+
+  public getAllByType(type: string): Observable<EnrichmentEntry[]> {
+    return this.http.get(`http://localhost:3000/api/v1/enrichments/${type}/entries`)
+      .pipe(
+        map((entries: EnrichmentEntry[]) => {
+          return entries;
+        }),
+        catchError((res: HttpErrorResponse) => {
+          return throwError(res);
+        })
+      );
+  }
+}


### PR DESCRIPTION
This PR introduces a new service that is responsible for communicating with APIs via the HTTP Client. The side effect is still in an ngrx effect which calls the appropriate service methods.

I also added error handling. In case of having an http error, the effect calls Ant's message service to provide useful information to the user.